### PR TITLE
AP: Add dev-only JWT signing endpoint

### DIFF
--- a/backend/ap/.env.sample
+++ b/backend/ap/.env.sample
@@ -2,6 +2,10 @@ GRAPHQL_ENDPOINT=http://sample.com/opnVote
 SERVER_URL=http://sample.com
 AP_ID=1 # AP ID registered on the smart contract
 
+# DEV ONLY — path to DEV AP JWT private key
+# Only loaded when NODE_ENV=development
+# DEV_AP_JWT_PRIVATE_KEY_PATH=./keys/dev-ap-private.pem
+
 # if this node instance is responsible for running ssl, provide it with ssl key + cert
 #SSL_KEY_PATH=./keys/server.key
 #SSL_CERT_PATH=./keys/server.cert

--- a/backend/ap/.gitignore
+++ b/backend/ap/.gitignore
@@ -1,2 +1,3 @@
 **/.env
 **/keys/
+ecosystem.config.js

--- a/backend/ap/src/app.ts
+++ b/backend/ap/src/app.ts
@@ -13,8 +13,10 @@ import http from 'http'
 import swaggerUi from 'swagger-ui-express'
 import swaggerSpec from './config/swaggerConfig'
 import authorizeRoutes from './routes/authorize'
+import devSignRoutes from './routes/devSign'
 
 const AP_JWT_PUBLIC_KEY_PATH = process.env.AP_JWT_PUBLIC_KEY_PATH
+const DEV_AP_JWT_PRIVATE_KEY_PATH = process.env.DEV_AP_JWT_PRIVATE_KEY_PATH
 const SERVER_URL = process.env.SERVER_URL
 const SSL_KEY_PATH = process.env.SSL_KEY_PATH
 const SSL_CERT_PATH = process.env.SSL_CERT_PATH
@@ -58,6 +60,19 @@ try {
   process.exit(1)
 }
 
+if (process.env.NODE_ENV === 'development') {
+  if (DEV_AP_JWT_PRIVATE_KEY_PATH) {
+    try {
+      const devPrivateKey = fs.readFileSync(path.resolve(DEV_AP_JWT_PRIVATE_KEY_PATH), 'utf8')
+      app.set('DEV_AP_JWT_PRIVATE_KEY', devPrivateKey)
+      console.log('✅ [DEV] AP JWT Priv Key loaded')
+    } catch (error) {
+      console.error('❌ [DEV] Failed to load DEV AP JWT Priv Key:', error)
+      process.exit(1)
+    }
+  }
+}
+
 app.set('AP_ID', AP_ID)
 
 if (SSL_KEY_PATH && SSL_CERT_PATH) {
@@ -86,6 +101,10 @@ dataSource
     app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec))
 
     app.use('/api/authorize', authorizeRoutes)
+
+    if (process.env.NODE_ENV === 'development') {
+      app.use('/api/dev/sign', devSignRoutes)
+    }
 
     app.get('/', (req, res) => {
       res.redirect('/api-docs')

--- a/backend/ap/src/routes/devSign.ts
+++ b/backend/ap/src/routes/devSign.ts
@@ -1,0 +1,79 @@
+import { Request, Response, Router } from 'express'
+import jwt from 'jsonwebtoken'
+import { ApiResponse } from '../types/apiResponses'
+
+const router = Router()
+
+/**
+ * @openapi
+ * /api/dev/sign:
+ *   post:
+ *     summary: "[DEV] Sign any payload and return a JWT"
+ *     description: "Issues a JWT signed with AP priv key. Only available when NODE_ENV=developmen."
+ *     tags: [Dev]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - payload
+ *             properties:
+ *               payload:
+ *                 type: object
+ *                 description: "Any JWT payload e.g. { voterId: 1, electionId: 6 }"
+ *               expiresIn:
+ *                 type: string
+ *                 description: "Optional expiry, e.g. '1h', '7d'"
+ *     responses:
+ *       200:
+ *         description: Signed JWT
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     token:
+ *                       type: string
+ *                 error:
+ *                   type: string
+ *                   nullable: true
+ *       400:
+ *         description: Invalid request body
+ *       500:
+ *         description: Dev signing key not configured
+ */
+router.post('/', (req: Request, res: Response) => {
+  const { payload, expiresIn } = req.body
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return res.status(400).json({
+      data: null,
+      error: 'Invalid request: payload must be a non-array object',
+    } as ApiResponse<null>)
+  }
+
+  const privateKey = req.app.get('DEV_AP_JWT_PRIVATE_KEY')
+  if (!privateKey) {
+    return res.status(500).json({
+      data: null,
+      error: 'Dev signing key not configured',
+    } as ApiResponse<null>)
+  }
+
+  const token = jwt.sign(payload, privateKey, {
+    algorithm: 'RS256',
+    ...(expiresIn ? { expiresIn } : {}),
+  })
+
+  return res.status(200).json({
+    data: { token },
+    error: null,
+  } as ApiResponse<{ token: string }>)
+})
+
+export default router


### PR DESCRIPTION
## Overview
Adds a way to get a valid JWT during development from AP-Server.

Closes #80 