### PR TITLE
fix: adapt ballot and votetransaction pages to new sendVotes logic

### DIFF
--- a/frontend/client/src/app/VotingContext.jsx
+++ b/frontend/client/src/app/VotingContext.jsx
@@ -1,13 +1,11 @@
 'use client';
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState } from 'react';
 
 const VotingContext = createContext(null);
 
 export function VotingProvider({ children }) {
     const [smartAccountClient, setSmartAccountClient] = useState(null);
-    useEffect(() => {
-        console.log(smartAccountClient);
-    }, [smartAccountClient]);
+
     return (
         <VotingContext.Provider value={{ smartAccountClient, setSmartAccountClient }}>
             {children}

--- a/frontend/client/src/app/VotingContext.jsx
+++ b/frontend/client/src/app/VotingContext.jsx
@@ -1,0 +1,18 @@
+'use client';
+import { createContext, useContext, useState, useEffect } from 'react';
+
+const VotingContext = createContext(null);
+
+export function VotingProvider({ children }) {
+    const [smartAccountClient, setSmartAccountClient] = useState(null);
+    useEffect(() => {
+        console.log(smartAccountClient);
+    }, [smartAccountClient]);
+    return (
+        <VotingContext.Provider value={{ smartAccountClient, setSmartAccountClient }}>
+            {children}
+        </VotingContext.Provider>
+    );
+}
+
+export const useVoting = () => useContext(VotingContext);

--- a/frontend/client/src/app/overview/Overview.jsx
+++ b/frontend/client/src/app/overview/Overview.jsx
@@ -16,7 +16,7 @@ const BOX_STATE_ACTIVATABLE = 'Activatable';
 const BOX_STATE_PASSIVE = 'Passive';
 
 export default function Overview() {
-    const { user, voting, updateVoting, updatePage, updateUserKey, updateTaskId } = useOpnVoteStore((state) => state);
+    const { user, voting, updateVoting, updatePage, updateUserKey } = useOpnVoteStore((state) => state);
     const { t } = useTranslation();
     const [boxes, setBoxes] = useState({
         id: { state: BOX_STATE_ACTIVATABLE, type: 'id' },

--- a/frontend/client/src/app/page.js
+++ b/frontend/client/src/app/page.js
@@ -19,6 +19,7 @@ import globalConst from "@/constants";
 import Faq from "@/app/faq/Faq";
 import Glossary from "@/app/glossary/Glossary";
 import Head from "@/components/Head";
+import { VotingProvider } from './VotingContext';
 
 export default function Home() {
     const { t } = useTranslation();
@@ -55,38 +56,42 @@ export default function Home() {
 
     return (
         <>
-            <HydrationZustand>
-                <>
-                    <Head />
-                    <div className="main">
-                        {page.current == globalConst.pages.LOADING && (
-                            <Loading loadingText={t("common.apploading")} />
-                        ) || page.current == globalConst.pages.OVERVIEW && (
-                            <Overview />
-                        ) || page.current == globalConst.pages.REGISTER && (
-                            <Register />
-                        ) || page.current == globalConst.pages.POLLINGSTATION && (
-                            <Pollingstation />
-                        ) || page.current == globalConst.pages.CREATEKEY && (
-                            <CreateSecret />
-                        ) || page.current == globalConst.pages.LOADKEY && (
-                            <LoadSecret />
-                        ) || page.current == globalConst.pages.LOADBALLOT && (
-                            <LoadBallot />
-                        ) || page.current == globalConst.pages.SHOWKEY && (
-                            <ShowSecret />
-                        ) || page.current == globalConst.pages.VOTETRANSACTION && (
-                            <VoteTransaction />
-                        ) || page.current == globalConst.pages.FAQ && (
-                            <Faq />
-                        ) || page.current == globalConst.pages.GLOSSARY && (
-                            <Glossary />
-                        ) || page.current == globalConst.pages.ERROR && (
-                            <ErrorReturn />
-                        )}
-                    </div>
-                </>
-            </HydrationZustand >
+            <VotingProvider>
+
+                <HydrationZustand>
+                    <>
+                        <Head />
+                        <div className="main">
+                            {page.current == globalConst.pages.LOADING && (
+                                <Loading loadingText={t("common.apploading")} />
+                            ) || page.current == globalConst.pages.OVERVIEW && (
+                                <Overview />
+                            ) || page.current == globalConst.pages.REGISTER && (
+                                <Register />
+                            ) || page.current == globalConst.pages.POLLINGSTATION && (
+                                <Pollingstation />
+                            ) || page.current == globalConst.pages.CREATEKEY && (
+                                <CreateSecret />
+                            ) || page.current == globalConst.pages.LOADKEY && (
+                                <LoadSecret />
+                            ) || page.current == globalConst.pages.LOADBALLOT && (
+                                <LoadBallot />
+                            ) || page.current == globalConst.pages.SHOWKEY && (
+                                <ShowSecret />
+                            ) || page.current == globalConst.pages.VOTETRANSACTION && (
+                                <VoteTransaction />
+                            ) || page.current == globalConst.pages.FAQ && (
+                                <Faq />
+                            ) || page.current == globalConst.pages.GLOSSARY && (
+                                <Glossary />
+                            ) || page.current == globalConst.pages.ERROR && (
+                                <ErrorReturn />
+                            )}
+                        </div>
+
+                    </>
+                </HydrationZustand >
+            </VotingProvider>
         </>
     );
 }

--- a/frontend/client/src/app/pollingstation/components/BallotPaper.jsx
+++ b/frontend/client/src/app/pollingstation/components/BallotPaper.jsx
@@ -7,11 +7,15 @@ import { useTranslation } from 'next-i18next';
 import { useOpnVoteStore } from "@/opnVoteStore";
 import globalConst from "@/constants";
 import Button from "@/components/Button";
+import { useVoting } from "@/app/VotingContext"
 import Notification from "@/components/Notification";
 
+
 export default function BallotPaper(props) {
+    const { setSmartAccountClient } = useVoting(); // Holt den Setter aus dem Context
+
     const { allowedToVote, votingCredentials, isVoteRecast, showElection } = props;
-    const { updatePage, voting, updateVoting, updateTaskId, taskId } = useOpnVoteStore((state) => state);
+    const { updatePage, voting, updateVoting, updateUserOpHash, userOpHash } = useOpnVoteStore((state) => state);
     const { t } = useTranslation();
     const [votes, setVotes] = useState({});
     const [electionState, setElectionState] = useState(globalConst.electionState.ONGOING);
@@ -21,7 +25,6 @@ export default function BallotPaper(props) {
 
     // manages what to show and how far we came incl. noticiation cause they also can cause some change in view.
     const [ballotStationState, setBallotStationState] = useState({
-        taskId: '',
         showSendError: false,
         pending: false,
     });
@@ -30,9 +33,11 @@ export default function BallotPaper(props) {
         setBallotStationState({ ...ballotStationState, pending: true });
         //result will be changed still ! we have to work with result (error notes.. redirect or sth else..)
         try {
-            const taskId = await sendVotes(votes, votingCredentials, voting.election.publicKey, isVoteRecast);
-            if (taskId) {
-                updateTaskId(taskId);
+            const userOpHash = await sendVotes(votes, votingCredentials, voting.election.publicKey, isVoteRecast, setSmartAccountClient);
+            if (userOpHash) {
+                updateUserOpHash(userOpHash);
+                updateVoting({ votesuccess: false, transactionViewUrl: '' }); //invalidate
+                updatePage({ current: globalConst.pages.VOTETRANSACTION });
             }
         } catch (e) {
             setBallotStationState({
@@ -54,10 +59,6 @@ export default function BallotPaper(props) {
         const tempEndTime = new Date(Number(voting.election.votingEndTime) * 1000);
         setStartDate(tempStartTime);
         setEndDate(tempEndTime);
-        if (taskId && taskId.length > 0) {
-            updateVoting({ votesuccess: false, transactionViewUrl: '' }); //invalidate
-            updatePage({ current: globalConst.pages.VOTETRANSACTION });
-        };
     }, []);
 
     return (

--- a/frontend/client/src/app/pollingstation/sendVotes.js
+++ b/frontend/client/src/app/pollingstation/sendVotes.js
@@ -128,10 +128,8 @@ export async function sendVotes(votes, votingCredentials, electionPublicKey, isR
 }
 
 export async function waitForReceipt(smartAccountClient, userOpHash) {
-    console.log('waitForReceipt');
     const receipt = await smartAccountClient.waitForUserOperationReceipt({ hash: userOpHash });
     const txHash = receipt.receipt.transactionHash;
-    console.log('receipt', receipt);
     if (!receipt.success) {
         throw new Error(`UserOp reverted: ${txHash}`);
     }

--- a/frontend/client/src/app/pollingstation/sendVotes.js
+++ b/frontend/client/src/app/pollingstation/sendVotes.js
@@ -11,7 +11,7 @@ import {
 import { createSmartAccountClient } from 'permissionless';
 import { to7702SimpleSmartAccount } from 'permissionless/accounts';
 
-export async function sendVotes(votes, votingCredentials, electionPublicKey, isRecast) {
+export async function sendVotes(votes, votingCredentials, electionPublicKey, isRecast, setSmartAccountClient) {
     // map votes into needed format
     const voterAccount = privateKeyToAccount(votingCredentials.voterWallet.privateKey);
     const OPNVOTE_ABI = [
@@ -103,6 +103,7 @@ export async function sendVotes(votes, votingCredentials, electionPublicKey, isR
             }),
         },
     });
+    setSmartAccountClient(smartAccountClient);
 
     const isDeployed = await smartAccount.isDeployed();
     const sendParams = {
@@ -122,9 +123,15 @@ export async function sendVotes(votes, votingCredentials, electionPublicKey, isR
         userOpHash = await smartAccountClient.sendUserOperation(sendParams);
     }
 
+
+    return userOpHash;
+}
+
+export async function waitForReceipt(smartAccountClient, userOpHash) {
+    console.log('waitForReceipt');
     const receipt = await smartAccountClient.waitForUserOperationReceipt({ hash: userOpHash });
     const txHash = receipt.receipt.transactionHash;
-
+    console.log('receipt', receipt);
     if (!receipt.success) {
         throw new Error(`UserOp reverted: ${txHash}`);
     }

--- a/frontend/client/src/app/votetransaction/VoteTransaction.jsx
+++ b/frontend/client/src/app/votetransaction/VoteTransaction.jsx
@@ -41,9 +41,7 @@ export default function VoteTransaction() {
 
     const checkTransaction = async () => {
         try {
-            console.log(smartAccountClient);
             const txHash = await waitForReceipt(smartAccountClient, userOpHash);
-            console.log('txHash', txHash);
             /*
             const { credentials } = checkBallot(voting.election, voting.registerCode);
             const voterAccount = privateKeyToAccount(credentials.voterWallet.privateKey);

--- a/frontend/client/src/app/votetransaction/VoteTransaction.jsx
+++ b/frontend/client/src/app/votetransaction/VoteTransaction.jsx
@@ -13,11 +13,14 @@ import globalConst from "@/constants";
 import { Check } from "lucide-react";
 import { privateKeyToAccount } from 'viem/accounts';
 import { checkBallot } from "@/util";
+import { useVoting } from '../VotingContext';
+import { waitForReceipt } from "../pollingstation/sendVotes";
 
 export default function VoteTransaction() {
-    const { taskId, voting, updateVoting, updateTaskId, updatePage } = useOpnVoteStore((state) => state);
+    const { userOpHash, voting, updateVoting, updateUserOpHash, updatePage } = useOpnVoteStore((state) => state);
     const { t } = useTranslation();
     const [transactionHash, setTransactionHash] = useState();
+    const { smartAccountClient } = useVoting(); // Holt den fertigen Client aus Seite 1
 
     const TRANSACTION_STATE_CHECKING = 'checking';
     const TRANSACTION_STATE_PENDING = 'pending';
@@ -38,7 +41,10 @@ export default function VoteTransaction() {
 
     const checkTransaction = async () => {
         try {
-
+            console.log(smartAccountClient);
+            const txHash = await waitForReceipt(smartAccountClient, userOpHash);
+            console.log('txHash', txHash);
+            /*
             const { credentials } = checkBallot(voting.election, voting.registerCode);
             const voterAccount = privateKeyToAccount(credentials.voterWallet.privateKey);
             const voterAddress = voterAccount.address.toLowerCase()
@@ -49,7 +55,7 @@ export default function VoteTransaction() {
                     console.log('Vote indexed in subgraph ✓', voteCasts[0].transactionHash); // leave in for now
                     setTransactionHash(voteCasts[0].transactionHash);
                     updateVoting({ votesuccess: true });
-                    updateTaskId(''); //invalidation to prevent wrong redirects from pollingstation
+                    updateUserOpHash(''); //invalidation to prevent wrong redirects from pollingstation
                     break;
                 }
                 if (attempt === 10) {
@@ -59,14 +65,17 @@ export default function VoteTransaction() {
                     await sleep(TRANSACTION_PENDING_DELAY);
                 }
             }
-            setVoteResultState({
-                ...voteResultState,
-                transactionStateText: t('votetransactionstate.statustitle.success'),
-                transactionStateSubText: t('votetransactionstate.statustext.success'),
-                transactionState: TRANSACTION_STATE_SUCCESS,
-                notificationText: t('votetransactionstate.info.success'),
-                notificationType: 'success',
-            });
+            */
+            if (txHash && txHash.length > 0) {
+                setVoteResultState({
+                    ...voteResultState,
+                    transactionStateText: t('votetransactionstate.statustitle.success'),
+                    transactionStateSubText: t('votetransactionstate.statustext.success'),
+                    transactionState: TRANSACTION_STATE_SUCCESS,
+                    notificationText: t('votetransactionstate.info.success'),
+                    notificationType: 'success',
+                });
+            }
 
         } catch (error) {
             console.log(error);
@@ -111,7 +120,7 @@ export default function VoteTransaction() {
 
     useEffect(() => {
         // be sure, that we only call it once at first
-        if (taskId?.length > 0 && voteResultState.transactionState === TRANSACTION_STATE_CHECKING) {
+        if (smartAccountClient && userOpHash?.length > 0 && voteResultState.transactionState === TRANSACTION_STATE_CHECKING) {
             checkTransaction();
             return;
         }
@@ -125,7 +134,7 @@ export default function VoteTransaction() {
                 notificationType: 'success',
             });
         }
-    }, [taskId]);
+    }, [userOpHash, smartAccountClient]);
 
     return (
         <>
@@ -171,7 +180,7 @@ export default function VoteTransaction() {
                 </div>
                 {voteResultState.transactionState == TRANSACTION_STATE_ERROR_RETRY && (
                     <div className="op__padding_standard_top">
-                        <Button type="primary" onClick={() => { updateTaskId(''); updatePage({ current: globalConst.pages.POLLINGSTATION }, modes.replace); }}>{t("votetransactionstate.errorretry")}</Button>
+                        <Button type="primary" onClick={() => { updateUserOpHash(''); updatePage({ current: globalConst.pages.POLLINGSTATION }, modes.replace); }}>{t("votetransactionstate.errorretry")}</Button>
                     </div>
                 )}
             </div>

--- a/frontend/client/src/app/votetransaction/VoteTransaction.jsx
+++ b/frontend/client/src/app/votetransaction/VoteTransaction.jsx
@@ -42,7 +42,7 @@ export default function VoteTransaction() {
     const checkTransaction = async () => {
         try {
             const txHash = await waitForReceipt(smartAccountClient, userOpHash);
-            /*
+
             const { credentials } = checkBallot(voting.election, voting.registerCode);
             const voterAccount = privateKeyToAccount(credentials.voterWallet.privateKey);
             const voterAddress = voterAccount.address.toLowerCase()
@@ -63,7 +63,7 @@ export default function VoteTransaction() {
                     await sleep(TRANSACTION_PENDING_DELAY);
                 }
             }
-            */
+
             if (txHash && txHash.length > 0) {
                 setVoteResultState({
                     ...voteResultState,

--- a/frontend/client/src/components/DataLoad.jsx
+++ b/frontend/client/src/components/DataLoad.jsx
@@ -18,7 +18,7 @@ export default function DataLoad() {
     });
 
     const [getElection, { data: dataElection, loading: loadingElection }] = getElectionData(localState.electionId);
-    const { voting, updateVoting, page, updatePage, user, clearUser, updateTaskId } = useOpnVoteStore((state) => state);
+    const { voting, updateVoting, page, updatePage, user, clearUser, updateUserOpHash } = useOpnVoteStore((state) => state);
 
     useEffect(() => {
         const onHashChange = (event) => {
@@ -116,7 +116,7 @@ export default function DataLoad() {
                     ...votingUpdate,
                 };
                 // remove any possibly stored task id, @todo: why isn't this part of voting?
-                updateTaskId('');
+                updateUserOpHash('');
                 // if a fragment is given, we switch to that page, regardless of user/election changes, overview otherwise
                 let targetPage = localState.fragment && Object.values(globalConst.pages).includes(localState.fragment)
                     ? localState.fragment

--- a/frontend/client/src/components/Head.jsx
+++ b/frontend/client/src/components/Head.jsx
@@ -11,7 +11,7 @@ import LanguageSwitchSelect from "@/components/LanguageSwitchSelect";
 
 export default function Head() {
     const { t } = useTranslation();
-    const { updatePage, updateUserKey, updateVoting, updateTaskId, page } = useOpnVoteStore((state) => state);
+    const { updatePage, updateUserKey, updateVoting, page } = useOpnVoteStore((state) => state);
 
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/frontend/client/src/opnVoteStore.js
+++ b/frontend/client/src/opnVoteStore.js
@@ -67,7 +67,7 @@ export const useOpnVoteStore = create(
         (set, get) => ({
             user: emptyUser,
             voting: emptyVoting,
-            taskId: '',
+            userOpHash: '',
             page: {
                 loading: true,
                 previous: null,
@@ -96,7 +96,7 @@ export const useOpnVoteStore = create(
                     election: state.voting.election,
                     electionInformation: state.voting.electionInformation,
                 },
-                taskId: '',
+                userOpHash: '',
             })),
             updateVoting: (votingData) =>
                 set((state) => ({
@@ -117,8 +117,8 @@ export const useOpnVoteStore = create(
                     }
                 }
             },
-            updateTaskId: (update) => set(() => ({
-                taskId: update
+            updateUserOpHash: (update) => set(() => ({
+                userOpHash: update
             })),
         }),
         {


### PR DESCRIPTION
resolves #101 

with the new logic without gelato we dont have a taskId anymore. 
i splitted the sendVote logic into the real send and the wait of receipt 
the smartAccountClient is putted into a contextprovider because its needed on two places.
we get userOpHash instead of txHash first and on the votetransactionpage we get the txHash itsself
i left the logic for votecasts / querySubgraphTransactionState for now as it is.

how to test? simply go through and vote. there should be the pending and success message now.