### PR TITLE
imp: change gnosis link

### DIFF
--- a/frontend/client/src/app/votetransaction/VoteTransaction.jsx
+++ b/frontend/client/src/app/votetransaction/VoteTransaction.jsx
@@ -104,7 +104,7 @@ export default function VoteTransaction() {
 
     const BlockchainLinkText = (props) => {
         const { transactionHash } = props;
-        const shortLink = `https://gnosisscan.io/tx/${transactionHash}`;
+        const shortLink = `https://gnosis.blockscout.com/tx/${transactionHash}`;
         return (
             <Link
                 target="_blank"


### PR DESCRIPTION
"📢 Gnosisscan will be deprecated as of August 11th at 23:59 UTC. Please visit [Deprecation of Block Explorer](https://info.etherscan.com/discontinuation-of-a-block-explorer/) for more information. The Gnosisscan API remains accessible via API Pro after explorer deprecation." 

so we change link to https://gnosis.blockscout.com/

test: vote and test wether the link is working :) 