### PR TITLE
feat: add small loading graphic when sending vote #156

### DIFF
--- a/frontend/client/public/locales/de/translation.json
+++ b/frontend/client/public/locales/de/translation.json
@@ -187,6 +187,7 @@
     "pollingstation.button.errorpopup.button": "Schließen",
     "pollingstation.button.errorpopup.headline": "Verarbeitung der Stimme fehlgeschlagen",
     "pollingstation.button.errorpopup.link": "Technische Details anzeigen",
+    "pollingstation.button.pending": "Ihr Stimmzettel wird übermittelt. Das kann ein paar Sekunden dauern. Sie werden dann automatisch weitergeleitet.",
     "pollingstation.button.savevotes": "Stimmzettel abgeben",
     "pollingstation.button.uploadballot": "Wahlschein hochladen",
     "pollingstation.electionHeader.countdown.dateuntil": "bis",

--- a/frontend/client/public/locales/en/translation.json
+++ b/frontend/client/public/locales/en/translation.json
@@ -187,6 +187,7 @@
     "pollingstation.button.errorpopup.button": "Close",
     "pollingstation.button.errorpopup.headline": "Vote processing failed",
     "pollingstation.button.errorpopup.link": "Show technical details",
+    "pollingstation.button.pending": "Your vote is being sent. This may take a few seconds. You'll be redirected afterwards.",
     "pollingstation.button.savevotes": "Send vote",
     "pollingstation.button.uploadballot": "Upload election permit",
     "pollingstation.electionHeader.countdown.dateuntil": "until",

--- a/frontend/client/src/app/pollingstation/components/BallotPaper.jsx
+++ b/frontend/client/src/app/pollingstation/components/BallotPaper.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'next-i18next';
 import { useOpnVoteStore } from "@/opnVoteStore";
 import globalConst from "@/constants";
 import Button from "@/components/Button";
+import Loading from "@/components/Loading";
 import { useVoting } from "@/app/VotingContext";
 import Notification from "@/components/Notification";
 import { VoteOption } from "votingsystem";
@@ -160,6 +161,11 @@ export default function BallotPaper(props) {
                                 id="test_btn_sendvote"
                             >{t("pollingstation.button.savevotes")}</Button>
                         </div>
+                        {ballotStationState.pending && (
+                            <div className="op__flex_center-center">
+                                <Loading theme="small"/><span>{t('pollingstation.button.pending')}</span>
+                            </div>
+                        )}
                         {ballotStationState.showSendError && (
                             <Notification
                                 type="error"


### PR DESCRIPTION
resolves #156 

as described in the ticket, there will now be a small loading graphic and description when the ballot is being sent.